### PR TITLE
Feat/add refund

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ $provider = Providers::OpenPix;
 $phPixService = PhPixServiceFactory::make($provider, $client);
 ```
 
+## Cobranças
 ### Obter Cobrança por Id
 ```php
 $chargeId = 'chargeId';
@@ -69,4 +70,26 @@ $chargeRequest = new ChargeRequest(
     ]
 );
 $charge = $phPixService->charges()->create($chargeRequest);
+```
+## Estornos
+### Obter Estorno por Id
+```php
+$refundId = 'refundId';
+$refund = $phPixService->refund()->getById($refundId);
+```
+
+### Obter todos os Estornos
+```php
+$refund = $phPixService->refund()->getAll();
+```
+### Criar Estorno
+Todos os campos que podem ser utilizados para criação do estorno podem ser consultados na própria classe de Request chamada.
+```php
+use PedroBruning\PhPix\Models\OpenPix\RefundRequest;
+$refundRequest = new RefundRequest(
+    value: 100,
+    transactionEndToEndId: 'validTransactionEndToEndId',
+    correlationId: 'validCorrelation'
+);
+$refund = $phPixService->refunds()->create($refundRequest);
 ```

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ use PedroBruning\PhPix\Services\Providers;
 use Symfony\Component\HttpClient\HttpClient; 
 
 //INSTÂNCIA
-$provider = Providers::OpenPix;
+$provider = Providers::YourProvider;
 $phPixService = PhPixServiceFactory::make($provider, $client);
 ```
 

--- a/src/Models/OpenPix/RefundRequest.php
+++ b/src/Models/OpenPix/RefundRequest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace PedroBruning\PhPix\Models\OpenPix;
+
+use PedroBruning\PhPix\Models\Contracts\Request;
+
+class RefundRequest implements Request
+{
+
+    public function __construct(
+        private int $value,
+        private string $transactionEndToEndId,
+        private string $correlationId
+    )
+    {
+    }
+
+    public function getPayload(): array
+    {
+        return [
+            'value' => $this->value,
+            'transactionEndToEndId' => $this->transactionEndToEndId,
+            'correlationID' => $this->correlationId
+        ];
+    }
+}

--- a/src/Services/Contracts/PhPixService.php
+++ b/src/Services/Contracts/PhPixService.php
@@ -5,4 +5,6 @@ namespace PedroBruning\PhPix\Services\Contracts;
 interface PhPixService
 {
     public function charges(): ChargeService;
+
+    public function refunds(): RefundService;
 }

--- a/src/Services/Contracts/RefundService.php
+++ b/src/Services/Contracts/RefundService.php
@@ -4,11 +4,11 @@ namespace PedroBruning\PhPix\Services\Contracts;
 
 use PedroBruning\PhPix\Models\Contracts\Request;
 
-interface ChargeService
+interface RefundService
 {
     public function getById(string $id): array;
 
-    public function getByFilter(array $filter): array;
+    public function getAll(): array;
 
-    public function create(Request $chargeRequest): array;
+    public function create(Request $refundRequest): array;
 }

--- a/src/Services/OpenPix/OpenPixRefundService.php
+++ b/src/Services/OpenPix/OpenPixRefundService.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace PedroBruning\PhPix\Services\OpenPix;
+
+use PedroBruning\PhPix\Models\Contracts\Request;
+use PedroBruning\PhPix\Services\Contracts\RefundService;
+use PedroBruning\PhPix\Services\Traits\ReturnsError;
+use Symfony\Component\HttpClient\Exception\ClientException;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+class OpenPixRefundService implements RefundService
+{
+    use ReturnsError;
+
+    public function __construct(private HttpClientInterface $client)
+    {
+    }
+
+    public function getById(string $id): array
+    {
+        try {
+            $response = $this->client->request('GET', "refund/$id");
+            return $response->toArray();
+        } catch (ClientException $exception) {
+            return $this->returnError($exception);
+        }
+    }
+
+    public function getAll(): array
+    {
+        try {
+            $response = $this->client->request('GET', "refund");
+            return $response->toArray();
+        } catch (ClientException $exception) {
+            return $this->returnError($exception);
+        }
+    }
+
+    public function create(Request $refundRequest): array
+    {
+        try {
+            $payload = [
+                'json' => $refundRequest->getPayload()
+            ];
+            $response = $this->client
+                ->request('POST', 'refund', $payload);
+            return $response->toArray();
+        }  catch (ClientException $exception) {
+            return $this->returnError($exception);
+        }
+    }
+}

--- a/src/Services/OpenPix/OpenPixService.php
+++ b/src/Services/OpenPix/OpenPixService.php
@@ -4,15 +4,21 @@ namespace PedroBruning\PhPix\Services\OpenPix;
 
 use PedroBruning\PhPix\Services\Contracts\ChargeService;
 use PedroBruning\PhPix\Services\Contracts\PhPixService;
+use PedroBruning\PhPix\Services\Contracts\RefundService;
 
 class OpenPixService implements PhPixService
 {
 
-    public function __construct(private ChargeService $chargeService)
+    public function __construct(private ChargeService $chargeService, private RefundService $refundService)
     {}
 
     public function charges(): ChargeService
     {
         return $this->chargeService;
+    }
+
+    public function refunds(): RefundService
+    {
+        return $this->refundService;
     }
 }

--- a/tests/Unit/Services/OpenPix/OpenPixRefundServiceTests.php
+++ b/tests/Unit/Services/OpenPix/OpenPixRefundServiceTests.php
@@ -1,0 +1,164 @@
+<?php
+
+namespace Tests\Unit\Services\OpenPix;
+
+use PedroBruning\PhPix\Models\OpenPix\RefundRequest;
+use PedroBruning\PhPix\Services\OpenPix\OpenPixRefundService;
+use PedroBruning\PhPix\Services\Contracts\RefundService;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\Exception\ClientException;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+class OpenPixRefundServiceTests extends TestCase
+{
+    private function makeSut(array $return): RefundService
+    {
+        $responseInterfaceStub = $this->createStub(ResponseInterface::class);
+        $responseInterfaceStub->method('toArray')->willReturn($return);
+        $clientStub = $this->createStub(HttpClientInterface::class);
+        $clientStub->method('request')->willReturn($responseInterfaceStub);
+        return new OpenPixRefundService($clientStub);
+    }
+
+    private function makeSutWithClientThrowing(): RefundService
+    {
+        $clientStub = $this->createStub(HttpClientInterface::class);
+        $responseInterfaceStub = $this->createMock(ResponseInterface::class);
+        $responseInterfaceStub
+            ->method('getInfo')
+            ->withConsecutive(['http_code'], ['url'], ['response_headers'])
+            ->willReturnOnConsecutiveCalls('400', 'some_url', []);
+        $clientStub->method('request')
+            ->willThrowException(new ClientException($responseInterfaceStub));
+        return new OpenPixRefundService($clientStub);
+    }
+
+    public function test_getById_returns_valid_refund()
+    {
+        $return = $this->validGetByIdResponse();
+        $sut = $this->makeSut($return);
+        $id = 'validId';
+
+        $result = $sut->getById($id);
+
+        $this->assertEquals($return, $result);
+    }
+
+    public function test_getById_returns_error_body_if_client_exception_is_thrown()
+    {
+        $return = $this->validExceptionResponse();
+        $sut = $this->makeSutWithClientThrowing();
+        $id = 'validId';
+
+        $result = $sut->getById($id);
+
+        $this->assertEquals($return, $result);
+    }
+
+    public function test_getAll_returns_valid_refunds()
+    {
+        $return = $this->validGetAllResponse();
+        $sut = $this->makeSut($return);
+
+        $response = $sut->getAll();
+
+        $this->assertEquals($return, $response);
+    }
+
+    public function test_getByAll_returns_error_body_if_client_exception_is_thrown()
+    {
+        $return = $this->validExceptionResponse();
+        $sut = $this->makeSutWithClientThrowing();
+
+        $result = $sut->getAll();
+
+        $this->assertEquals($return, $result);
+    }
+
+    public function test_create_returns_valid_charge()
+    {
+        //Arrange
+        $return = $this->validCreateResponse();
+        $sut = $this->makeSut($return);
+        $charge = $this->fakeRefund();
+        //Act
+        $response = $sut->create($charge);
+        $this->assertEquals($return, $response);
+    }
+
+    public function test_create_returns_error_body_if_client_exception_is_thrown()
+    {
+        //Arrange
+        $sut = $this->makeSutWithClientThrowing();
+        $charge = $this->fakeRefund();
+        //Act
+        $result = $sut->create($charge);
+        //Assert
+        $this->assertEquals($result, $this->validExceptionResponse());
+    }
+
+
+    private function validGetByIdResponse(): array
+    {
+        return [
+            'refund' => [
+                'value' => 100,
+                'correlationID' => '7777-6f71-427a-bf00-241681624586',
+                'refundId' => '11bf5b37e0b842e08dcfdc8c4aefc000',
+                'returnIdentification' => 'D09089356202108032000a543e325902'
+            ]
+        ];
+    }
+
+    private function validExceptionResponse(): array
+    {
+        return [
+            'error' => 'HTTP 400 returned for "some_url".'
+        ];
+    }
+
+    private function validGetAllResponse(): array
+    {
+        return [
+            "pageInfo" => [
+                "skip" => 0,
+                "limit" => 10,
+                "totalCount" => 20,
+                "hasPreviousPage" => false,
+                "hasNextPage" => true
+            ],
+            "refunds" => [
+                [
+                    "status" => "IN_PROCESSING",
+                    "value" => 100,
+                    "correlationID" => "9134e286-6f71-427a-bf00-241681624586",
+                    "refundId" => "9134e2866f71427abf00241681624586",
+                    "time" => "2021-03-02T17:28:51.882Z"
+                ]
+            ]
+        ];
+    }
+
+    private function validCreateResponse(): array
+    {
+        return [
+            "refund" => [
+                "status" => "IN_PROCESSING",
+                "value" => 100,
+                "correlationID" => "9134e286-6f71-427a-bf00-241681624586",
+                "refundId" => "9134e2866f71427abf00241681624586",
+                "time" => "2021-03-02T17:28:51.882Z"
+            ]
+        ];
+    }
+
+    private function fakeRefund(): RefundRequest
+    {
+        return new RefundRequest(
+            value: 100,
+            correlationId: '9134e286-6f71-427a-bf00-241681624586',
+            transactionEndToEndId: '9134e286-6f71-427a-bf00-241681624586'
+        );
+    }
+}

--- a/tests/Unit/Services/OpenPix/OpenPixServiceTests.php
+++ b/tests/Unit/Services/OpenPix/OpenPixServiceTests.php
@@ -3,6 +3,7 @@
 namespace Tests\Unit\Services\OpenPix;
 
 use PedroBruning\PhPix\Services\Contracts\ChargeService;
+use PedroBruning\PhPix\Services\Contracts\RefundService;
 use PedroBruning\PhPix\Services\OpenPix\OpenPixService;
 use PHPUnit\Framework\TestCase;
 
@@ -13,6 +14,14 @@ class OpenPixServiceTests extends TestCase
         $chargeServiceMock = $this->createMock(ChargeService::class);
         $sut = new OpenPixService($chargeServiceMock);
         $this->assertEquals($chargeServiceMock, $sut->charges());
+    }
+
+    public function test_refunds_method_returns_instance_of_charge_service()
+    {
+        $chargeServiceMock = $this->createMock(ChargeService::class);
+        $refundServiceMock = $this->createMock(RefundService::class);
+        $sut = new OpenPixService(chargeService: $chargeServiceMock, refundService: $refundServiceMock);
+        $this->assertEquals($refundServiceMock, $sut->refunds());
     }
 
 }


### PR DESCRIPTION
# Changelog
Adicionado serviço para consumo de API's de estorno do OpenPix.

## Estornos
### Obter Estorno por Id
```php
$refundId = 'refundId';
$refund = $phPixService->refund()->getById($refundId);
```

### Obter todos os Estornos
```php
$refund = $phPixService->refund()->getAll();
```
### Criar Estorno
Todos os campos que podem ser utilizados para criação do estorno podem ser consultados na própria classe de Request chamada.
```php
use PedroBruning\PhPix\Models\OpenPix\RefundRequest;
$refundRequest = new RefundRequest(
    value: 100,
    transactionEndToEndId: 'validTransactionEndToEndId',
    correlationId: 'validCorrelation'
);
$refund = $phPixService->refunds()->create($refundRequest);
```
## Mudanças
- Adicionada integração com OpenPix com as rotas de Estorno