### PR TITLE
Fix/create charge openpix

### DIFF
--- a/src/Models/OpenPix/ChargeRequest.php
+++ b/src/Models/OpenPix/ChargeRequest.php
@@ -10,7 +10,7 @@ class ChargeRequest implements Request
         'comment', 'identifier', 'customer', 'expiresIn', 'additionalInfo'
     ];
 
-    private array $optionalFields;
+    private array $optionalFields = [];
 
     public function __construct(
         private string $correlationId,

--- a/tests/Unit/Models/OpenPix/ChargeRequestTests.php
+++ b/tests/Unit/Models/OpenPix/ChargeRequestTests.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Tests\Unit\Models\OpenPix;
+
+use PedroBruning\PhPix\Models\OpenPix\ChargeRequest;
+use PHPUnit\Framework\TestCase;
+
+class ChargeRequestTests extends TestCase
+{
+    public function test_optional_fields_are_filled_correctly()
+    {
+        $comment = 'Valid Comment';
+        $identifier = 'ValidIdentifier';
+        $expiresIn = 1800;
+        $customer = [
+            'name' => 'Valid Name',
+            'email' => 'Valid Email',
+            'phone' => '0000000000000',
+            'taxID' => '00000000000'
+        ];
+        $additionalInfo = [
+            'Notes' => 'Valid Note'
+        ];
+
+        $sut = new ChargeRequest(
+            correlationId: 'validCorrelationId',
+            value: 100,
+            comment: $comment,
+            identifier: $identifier,
+            expiresIn: $expiresIn,
+            customer: $customer,
+            additionalInfo: $additionalInfo
+        );
+        $actual = $sut->getPayload();
+        $this->assertEquals($comment, $actual['comment']);
+        $this->assertEquals($identifier, $actual['identifier']);
+        $this->assertEquals($expiresIn, $actual['expiresIn']);
+        $this->assertEquals($customer, $actual['customer']);
+        $this->assertEquals($additionalInfo, $actual['additionalInfo']);
+    }
+    public function test_optional_fields_are_not_filled_if_not_passed()
+    {
+        $sut = new ChargeRequest(
+            correlationId: 'validCorrelationId',
+            value: 100
+        );
+        $array = $sut->getPayload();
+        $this->assertArrayNotHasKey('comment', $array);
+        $this->assertArrayNotHasKey('identifier', $array);
+        $this->assertArrayNotHasKey('expiresIn', $array);
+        $this->assertArrayNotHasKey('customer', $array);
+        $this->assertArrayNotHasKey('additionalInfo', $array);
+    }
+}


### PR DESCRIPTION
# Changes
- Fixed error ```Typed property PedroBruning\PhPix\Models\OpenPix\ChargeRequest::$optionalFields must not be accessed before initialization```
- Added tests to the class PedroBruning\PhPix\Models\OpenPix\ChargeRequest